### PR TITLE
refactor: minimize "Intent" struct usage in the contract

### DIFF
--- a/contracts/src/chains/MockUntronIntents.sol
+++ b/contracts/src/chains/MockUntronIntents.sol
@@ -25,7 +25,7 @@ contract MockUntronIntents is Initializable, OwnableUpgradeable, UntronIntents {
     }
 
     /// @inheritdoc UntronIntents
-    function _validateFill(Intent memory, bytes calldata) internal view override returns (bool) {
+    function _validateFills(FillInstruction[] calldata, bytes calldata) internal view override returns (bool) {
         return msg.sender == owner();
     }
 }

--- a/contracts/src/interfaces/IUntronIntents.sol
+++ b/contracts/src/interfaces/IUntronIntents.sol
@@ -32,7 +32,7 @@ interface IUntronIntents is IOriginSettler {
 
     /// @notice Get if an order was created and not yet reclaimed
     /// @param orderId The ID of the order
-    /// @return bool if it's created and not yet reclaimed
+    /// @return True if the order exists and has not been reclaimed, false otherwise
     function orders(bytes32 orderId) external view returns (bool);
 
     /// @notice Reclaim the locked funds for a filled order

--- a/contracts/src/interfaces/IUntronIntents.sol
+++ b/contracts/src/interfaces/IUntronIntents.sol
@@ -30,16 +30,15 @@ interface IUntronIntents is IOriginSettler {
     /// @return The gasless nonce for the user
     function gaslessNonces(address user) external view returns (uint256);
 
-    /// @notice Get the intent hash for an order
+    /// @notice Get if an order was created and not yet reclaimed
     /// @param orderId The ID of the order
-    /// @return The intent hash for the order
-    function orders(bytes32 orderId) external view returns (bytes32);
+    /// @return bool if it's created and not yet reclaimed
+    function orders(bytes32 orderId) external view returns (bool);
 
     /// @notice Reclaim the locked funds for a filled order
-    /// @param orderId The ID of the order
-    /// @param intent The intent of the order
+    /// @param order The resolved order which was filled
     /// @param proof The proof of fulfillment of the order
-    function reclaim(bytes32 orderId, Intent memory intent, bytes calldata proof) external;
+    function reclaim(ResolvedCrossChainOrder calldata order, bytes calldata proof) external;
 
     /// @notice Multicall helper function to multi-permit and openFor in one call
     /// @param order The order to open

--- a/contracts/test/UntronIntents.t.sol
+++ b/contracts/test/UntronIntents.t.sol
@@ -511,7 +511,8 @@ contract UntronIntentsTest is Test {
 
         uint256 balanceBefore = inputToken.balanceOf(user);
 
-        untronIntents.reclaim(untronIntents.resolve(order), "");
+        ResolvedCrossChainOrder memory resolvedOrder = untronIntents.resolve(order);
+        untronIntents.reclaim(resolvedOrder, "");
 
         uint256 balanceAfter = inputToken.balanceOf(user);
 

--- a/contracts/test/UntronIntents.t.sol
+++ b/contracts/test/UntronIntents.t.sol
@@ -263,7 +263,8 @@ contract UntronIntentsTest is Test {
         untronIntents.open(order);
         vm.stopPrank();
 
-        bytes32 orderId = keccak256(abi.encode(untronIntents.resolve(order)));
+        ResolvedCrossChainOrder memory resolvedOrder = untronIntents.resolve(order);
+        bytes32 orderId = keccak256(abi.encode(resolvedOrder));
         // Check that the order was created
         assertEq(untronIntents.orders(orderId), true);
     }

--- a/contracts/test/UntronIntents.t.sol
+++ b/contracts/test/UntronIntents.t.sol
@@ -634,7 +634,8 @@ contract UntronIntentsTest is Test {
         untronIntents.open(order);
         vm.stopPrank();
 
-        bytes32 orderId = keccak256(abi.encode(untronIntents.resolve(order)));
+        ResolvedCrossChainOrder memory resolvedOrder = untronIntents.resolve(order);
+        bytes32 orderId = keccak256(abi.encode(resolvedOrder));
         assertEq(untronIntents.orders(orderId), true);
 
         // Check that user's balance has decreased


### PR DESCRIPTION
now, "Intent" struct is only used while resolving the order into ResolvedCrossChainOrder. for everything else this type and its child types are used. also _validateFill is now _validateFills for future-proofness. and a bunch of bugfixes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Simplified order management with improved tracking of order existence.
	- Enhanced consistency in order ID generation based on resolved orders.
  
- **Bug Fixes**
	- Improved validation logic for fills to align with new order structure.

- **Documentation**
	- Updated interface to reflect changes in order querying and reclamation processes.

- **Tests**
	- Refined test cases to ensure correct handling of order resolution and intent management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->