### PR TITLE
fix double order creation

### DIFF
--- a/contracts/src/UntronIntents.sol
+++ b/contracts/src/UntronIntents.sol
@@ -185,6 +185,9 @@ abstract contract UntronIntents is IUntronIntents, Initializable {
         // Compute the order ID
         bytes32 orderId = keccak256(abi.encode(resolvedOrder));
 
+        // Ensure that such order doesn't exist already
+        require(!orders[orderId], "Order already exists");
+
         // Store the fact of the order
         orders[orderId] = true;
 
@@ -212,6 +215,9 @@ abstract contract UntronIntents is IUntronIntents, Initializable {
 
         // Compute the order ID
         bytes32 orderId = keccak256(abi.encode(resolvedOrder));
+
+        // Ensure that such order doesn't exist already
+        require(!orders[orderId], "Order already exists");
 
         // Store the fact of the order
         orders[orderId] = true;


### PR DESCRIPTION
currently the users (integrators) who interact with the contract wrong can push two orders that produce the same "resolved order" and thus the same order ID. if any of them is filled, the other one cannot be and the funds will be stuck forever. in the update we enforce that the order cannot be created if there's already an order with the same order ID

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced order management by preventing the creation of duplicate orders.
	- Added checks to ensure unique order IDs during the order creation process.

- **Bug Fixes**
	- Improved transaction handling by reverting with an error message if an order already exists.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->